### PR TITLE
parsing/grammar.cma must be linked with unix.cma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ plugins/micromega/csdpcert
 kernel/byterun/dllcoqrun.so
 states/initial.coq
 coqdoc.sty
-test-suite/lia.cache
+/lia.cache
 test-suite/trace
 test-suite/misc/universes/all_stdlib.v
 test-suite/misc/universes/universes.txt
@@ -61,6 +61,7 @@ test-suite/misc/universes/universes.txt
 doc/faq/html/
 doc/refman/csdp.cache
 doc/refman/trace
+doc/refman/Reference-Manual.out
 doc/refman/Reference-Manual.pdf
 doc/refman/Reference-Manual.ps
 doc/refman/cover.html
@@ -119,6 +120,7 @@ lib/compat.ml
 parsing/q_util.ml
 parsing/tacextend.ml
 parsing/q_constr.ml
+parsing/q_coqast.ml
 parsing/pcoq.ml
 parsing/vernacextend.ml
 parsing/argextend.ml
@@ -152,6 +154,7 @@ toplevel/mltop.optml
 toplevel/mltop.byteml
 kernel/byterun/coq_jumptbl.h
 kernel/copcodes.ml
+kernel/uint63.ml
 scripts/tolink.ml
 theories/Numbers/Natural/BigN/NMake_gen.v
 ide/index_urls.txt

--- a/Makefile.build
+++ b/Makefile.build
@@ -728,7 +728,7 @@ parsing/grammar.cma: | parsing/grammar.mllib.d
 	$(HIDE)$(OCAMLC) $(BYTEFLAGS) -pp "$(CAMLP4O) -I $(CAMLLIB) $(CAMLP4FLAGS) $^ -impl" -impl test.ml4 -o test-grammar
 	@rm -f test-grammar test.*
 	$(SHOW)'OCAMLC -a $@'   
-	$(HIDE)$(OCAMLC) $(BYTEFLAGS) $^ -linkall -a -o $@
+	$(HIDE)$(OCAMLC) $(BYTEFLAGS) -I $(CAMLLIB) $(CAMLP4FLAGS) $^ -linkall -a -o $@
 
 # toplevel/mltop.ml4 (ifdef Byte)
 

--- a/kernel/byterun/coq_fix_code.c
+++ b/kernel/byterun/coq_fix_code.c
@@ -12,7 +12,8 @@
    for fast computation of bounded (31bits) integers */
 
 #include <stdio.h>
-#include <stdlib.h> 
+#include <stdlib.h>
+#include <stdint.h>
 #include <caml/config.h>
 #include <caml/misc.h>
 #include <caml/mlvalues.h>

--- a/kernel/byterun/coq_fix_code.c
+++ b/kernel/byterun/coq_fix_code.c
@@ -168,7 +168,7 @@ value coq_tcode_of_code (value code, value size) {
     };
     *q++ = VALINSTR(instr);
     if (instr == SWITCH) {
-      uint32 i, sizes, const_size, block_size;
+      uint32_t i, sizes, const_size, block_size;
       COPY32(q,p); p++;
       sizes=*q++;
       const_size = sizes & 0xFFFF;
@@ -176,13 +176,13 @@ value coq_tcode_of_code (value code, value size) {
       sizes = const_size + block_size;
       for(i=0; i<sizes; i++) { COPY32(q,p); p++; q++; };
     } else if (instr == CLOSUREREC || instr==CLOSURECOFIX) {
-      uint32 i, n;
+      uint32_t i, n;
       COPY32(q,p); p++; /* ndefs */
       n = 3 + 2*(*q);  /* ndefs, nvars, start, typlbls,lbls*/
       q++;
       for(i=1; i<n; i++) { COPY32(q,p); p++; q++; };
     } else {
-      uint32 i, ar;
+      uint32_t i, ar;
       ar = arity[instr]; 
       for(i=0; i<ar; i++) { COPY32(q,p); p++; q++; };
     }

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -14,6 +14,7 @@
    for fast computation of bounded (31bits) integers */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <caml/callback.h>
 #include <signal.h>
 #include "coq_gc.h"

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -876,7 +876,7 @@ value coq_interprete
 /* Access to components of blocks */
         
       Instruct(SWITCH) {
-	uint32 sizes = *pc++;
+	uint32_t sizes = *pc++;
 	print_instr("SWITCH");
 	print_int(sizes & 0xFFFF);
 	if (Is_block(accu)) {

--- a/kernel/byterun/coq_uint63_native.h
+++ b/kernel/byterun/coq_uint63_native.h
@@ -1,45 +1,45 @@
-#define uint63_of_value(val) ((uint64)(val) >> 1)
+#define uint63_of_value(val) ((uint64_t)(val) >> 1)
 
 /* 2^63 * y + x as a value */
-//#define Val_intint(x,y) ((value)(((uint64)(x)) << 1 + ((uint64)(y) << 64)))
+//#define Val_intint(x,y) ((value)(((uint64_t)(x)) << 1 + ((uint64_t)(y) << 64)))
 
 #define uint63_zero ((value) 1) /* 2*0 + 1 */
 #define uint63_one ((value) 3) /* 2*1 + 1 */
 
 #define uint63_eq(x,y) ((x) == (y))
-#define uint63_eq0(x) ((x) == (uint64)1)
-#define uint63_lt(x,y) ((uint64) (x) < (uint64) (y))
-#define uint63_leq(x,y) ((uint64) (x) <= (uint64) (y))
+#define uint63_eq0(x) ((x) == (uint64_t)1)
+#define uint63_lt(x,y) ((uint64_t) (x) < (uint64_t) (y))
+#define uint63_leq(x,y) ((uint64_t) (x) <= (uint64_t) (y))
 
-#define uint63_add(x,y) ((value)((uint64) (x) + (uint64) (y) - 1))
-#define uint63_addcarry(x,y) ((value)((uint64) (x) + (uint64) (y) + 1))
-#define uint63_sub(x,y) ((value)((uint64) (x) - (uint64) (y) + 1))
-#define uint63_subcarry(x,y) ((value)((uint64) (x) - (uint64) (y) - 1))
+#define uint63_add(x,y) ((value)((uint64_t) (x) + (uint64_t) (y) - 1))
+#define uint63_addcarry(x,y) ((value)((uint64_t) (x) + (uint64_t) (y) + 1))
+#define uint63_sub(x,y) ((value)((uint64_t) (x) - (uint64_t) (y) + 1))
+#define uint63_subcarry(x,y) ((value)((uint64_t) (x) - (uint64_t) (y) - 1))
 #define uint63_mul(x,y) (Val_long(Long_val(x) * Long_val(y)))
 #define uint63_div(x,y) (Val_long(Long_val(x) / Long_val(y)))
 #define uint63_mod(x,y) (Val_long(Long_val(x) % Long_val(y)))
 
-#define uint63_lxor(x,y) ((value)(((uint64)(x) ^ (uint64)(y)) | 1))
-#define uint63_lor(x,y) ((value)((uint64)(x) | (uint64)(y)))
-#define uint63_land(x,y) ((value)((uint64)(x) & (uint64)(y)))
+#define uint63_lxor(x,y) ((value)(((uint64_t)(x) ^ (uint64_t)(y)) | 1))
+#define uint63_lor(x,y) ((value)((uint64_t)(x) | (uint64_t)(y)))
+#define uint63_land(x,y) ((value)((uint64_t)(x) & (uint64_t)(y)))
 
 /* TODO: is + or | better? OCAML uses + */
 /* TODO: is - or ^ better? */
-#define uint63_lsl(x,y) ((y) < (uint64) 127 ? ((value)((((uint64)(x)-1) << (uint63_of_value(y))) | 1)) : uint63_zero)
-#define uint63_lsr(x,y) ((y) < (uint64) 127 ? ((value)(((uint64)(x) >> (uint63_of_value(y))) | 1)) : uint63_zero)
-#define uint63_lsl1(x) ((value)((((uint64)(x)-1) << 1) +1))
-#define uint63_lsr1(x) ((value)(((uint64)(x) >> 1) |1))
+#define uint63_lsl(x,y) ((y) < (uint64_t) 127 ? ((value)((((uint64_t)(x)-1) << (uint63_of_value(y))) | 1)) : uint63_zero)
+#define uint63_lsr(x,y) ((y) < (uint64_t) 127 ? ((value)(((uint64_t)(x) >> (uint63_of_value(y))) | 1)) : uint63_zero)
+#define uint63_lsl1(x) ((value)((((uint64_t)(x)-1) << 1) +1))
+#define uint63_lsr1(x) ((value)(((uint64_t)(x) >> 1) |1))
 
 /* addmuldiv(p,x,y) = x * 2^p + y / 2 ^ (63 - p) */
 /* (modulo 2^63) for p <= 63 */
-value uint63_addmuldiv(uint64 p, uint64 x, uint64 y) {
-  uint64 shiftby = uint63_of_value(p);
-  value r = (value)((uint64)(x^1) << shiftby);
-  r |= ((uint64)y >> (63-shiftby)) | 1;
+value uint63_addmuldiv(uint64_t p, uint64_t x, uint64_t y) {
+  uint64_t shiftby = uint63_of_value(p);
+  value r = (value)((uint64_t)(x^1) << shiftby);
+  r |= ((uint64_t)y >> (63-shiftby)) | 1;
   return r;
 }
 
-value uint63_head0(uint64 x) {
+value uint63_head0(uint64_t x) {
   int r = 0;
   if (!(x & 0xFFFFFFFF00000000)) { x <<= 32; r += 32; }
   if (!(x & 0xFFFF000000000000)) { x <<= 16; r += 16; }
@@ -52,7 +52,7 @@ value uint63_head0(uint64 x) {
 
 value uint63_tail0(value x) {
   int r = 0;
-  x = (uint64)x >> 1;
+  x = (uint64_t)x >> 1;
   if (!(x & 0xFFFFFFFF)) { x >>= 32; r += 32; }
   if (!(x & 0x0000FFFF)) { x >>= 16; r += 16; }
   if (!(x & 0x000000FF)) { x >>= 8;  r += 8; }
@@ -63,14 +63,14 @@ value uint63_tail0(value x) {
 }
 
 value uint63_mulc(value x, value y, value* h) {
-  x = (uint64)x >> 1;
-  y = (uint64)y >> 1;
-  uint64 lx = x & 0xFFFFFFFF;
-  uint64 ly = y & 0xFFFFFFFF;
-  uint64 hx = x >> 32;
-  uint64 hy = y >> 32;
-  uint64 hr = hx * hy;
-  uint64 lr = lx * ly;
+  x = (uint64_t)x >> 1;
+  y = (uint64_t)y >> 1;
+  uint64_t lx = x & 0xFFFFFFFF;
+  uint64_t ly = y & 0xFFFFFFFF;
+  uint64_t hx = x >> 32;
+  uint64_t hy = y >> 32;
+  uint64_t hr = hx * hy;
+  uint64_t lr = lx * ly;
   lx *= hy;
   ly *= hx;
   hr += (lx >> 32) + (ly >> 32);
@@ -89,13 +89,13 @@ value uint63_mulc(value x, value y, value* h) {
 #define le128(xh,xl,yh,yl) (uint63_lt(xh,yh) || (uint63_eq(xh,yh) && uint63_leq(xl,yl)))
 
 value uint63_div21(value xh, value xl, value y, value* q) {
-  xh = (uint64)xh >> 1;
-  xl = ((uint64)xl >> 1) | ((uint64)xh << 63);
-  xh = (uint64)xh >> 1;
-  uint64 maskh = 0;
-  uint64 maskl = 1;
-  uint64 dh = 0;
-  uint64 dl = (uint64)y >> 1;
+  xh = (uint64_t)xh >> 1;
+  xl = ((uint64_t)xl >> 1) | ((uint64_t)xh << 63);
+  xh = (uint64_t)xh >> 1;
+  uint64_t maskh = 0;
+  uint64_t maskl = 1;
+  uint64_t dh = 0;
+  uint64_t dl = (uint64_t)y >> 1;
   int cmp = 1;
   while (dh >= 0 && cmp) {
     cmp = lt128(dh,dl,xh,xl);
@@ -104,9 +104,9 @@ value uint63_div21(value xh, value xl, value y, value* q) {
     maskh = (maskh << 1) | (maskl >> 63);
     maskl = maskl << 1;
   }
-  uint64 remh = xh;
-  uint64 reml = xl;
-  uint64 quotient = 0;
+  uint64_t remh = xh;
+  uint64_t reml = xl;
+  uint64_t quotient = 0;
   while (maskh | maskl) {
     if (le128(dh,dl,remh,reml)) {
       quotient = quotient | maskl;

--- a/kernel/byterun/int64_emul.h
+++ b/kernel/byterun/int64_emul.h
@@ -26,7 +26,7 @@
 #endif
 
 /* Unsigned comparison */
-static int I64_ucompare(uint64 x, uint64 y)
+static int I64_ucompare(uint64_t x, uint64_t y)
 {
   if (x.h > y.h) return 1;
   if (x.h < y.h) return -1;
@@ -38,19 +38,19 @@ static int I64_ucompare(uint64 x, uint64 y)
 #define I64_ult(x, y) (I64_ucompare(x, y) < 0)
 
 /* Signed comparison */
-static int I64_compare(int64 x, int64 y)
+static int I64_compare(int64_t x, int64_t y)
 {
-  if ((int32)x.h > (int32)y.h) return 1;
-  if ((int32)x.h < (int32)y.h) return -1;
+  if ((int32_t)x.h > (int32_t)y.h) return 1;
+  if ((int32_t)x.h < (int32_t)y.h) return -1;
   if (x.l > y.l) return 1;
   if (x.l < y.l) return -1;
   return 0;
 }
 
 /* Negation */
-static int64 I64_neg(int64 x)
+static int64_t I64_neg(int64_t x)
 {
-  int64 res;
+  int64_t res;
   res.l = -x.l;
   res.h = ~x.h;
   if (res.l == 0) res.h++;
@@ -58,9 +58,9 @@ static int64 I64_neg(int64 x)
 }
 
 /* Addition */
-static int64 I64_add(int64 x, int64 y)
+static int64_t I64_add(int64_t x, int64_t y)
 {
-  int64 res;
+  int64_t res;
   res.l = x.l + y.l;
   res.h = x.h + y.h;
   if (res.l < x.l) res.h++;
@@ -68,9 +68,9 @@ static int64 I64_add(int64 x, int64 y)
 }
 
 /* Subtraction */
-static int64 I64_sub(int64 x, int64 y)
+static int64_t I64_sub(int64_t x, int64_t y)
 {
-  int64 res;
+  int64_t res;
   res.l = x.l - y.l;
   res.h = x.h - y.h;
   if (x.l < y.l) res.h--;
@@ -78,13 +78,13 @@ static int64 I64_sub(int64 x, int64 y)
 }
 
 /* Multiplication */
-static int64 I64_mul(int64 x, int64 y)
+static int64_t I64_mul(int64_t x, int64_t y)
 {
-  int64 res;
-  uint32 prod00 = (x.l & 0xFFFF) * (y.l & 0xFFFF);
-  uint32 prod10 = (x.l >> 16) * (y.l & 0xFFFF);
-  uint32 prod01 = (x.l & 0xFFFF) * (y.l >> 16);
-  uint32 prod11 = (x.l >> 16) * (y.l >> 16);
+  int64_t res;
+  uint32_t prod00 = (x.l & 0xFFFF) * (y.l & 0xFFFF);
+  uint32_t prod10 = (x.l >> 16) * (y.l & 0xFFFF);
+  uint32_t prod01 = (x.l & 0xFFFF) * (y.l >> 16);
+  uint32_t prod11 = (x.l >> 16) * (y.l >> 16);
   res.l = prod00;
   res.h = prod11 + (prod01 >> 16) + (prod10 >> 16);
   prod01 = prod01 << 16; res.l += prod01; if (res.l < prod01) res.h++;
@@ -95,37 +95,37 @@ static int64 I64_mul(int64 x, int64 y)
 
 #define I64_is_zero(x) (((x).l | (x).h) == 0)
 
-#define I64_is_negative(x) ((int32) (x).h < 0)
+#define I64_is_negative(x) ((int32_t) (x).h < 0)
 
 /* Bitwise operations */
-static int64 I64_and(int64 x, int64 y)
+static int64_t I64_and(int64_t x, int64_t y)
 {
-  int64 res;
+  int64_t res;
   res.l = x.l & y.l;
   res.h = x.h & y.h;
   return res;
 }
 
-static int64 I64_or(int64 x, int64 y)
+static int64_t I64_or(int64_t x, int64_t y)
 {
-  int64 res;
+  int64_t res;
   res.l = x.l | y.l;
   res.h = x.h | y.h;
   return res;
 }
 
-static int64 I64_xor(int64 x, int64 y)
+static int64_t I64_xor(int64_t x, int64_t y)
 {
-  int64 res;
+  int64_t res;
   res.l = x.l ^ y.l;
   res.h = x.h ^ y.h;
   return res;
 }
 
 /* Shifts */
-static int64 I64_lsl(int64 x, int s)
+static int64_t I64_lsl(int64_t x, int s)
 {
-  int64 res;
+  int64_t res;
   s = s & 63;
   if (s == 0) return x;
   if (s < 32) {
@@ -138,9 +138,9 @@ static int64 I64_lsl(int64 x, int s)
   return res;
 }
 
-static int64 I64_lsr(int64 x, int s)
+static int64_t I64_lsr(int64_t x, int s)
 {
-  int64 res;
+  int64_t res;
   s = s & 63;
   if (s == 0) return x;
   if (s < 32) {
@@ -153,17 +153,17 @@ static int64 I64_lsr(int64 x, int s)
   return res;
 }
 
-static int64 I64_asr(int64 x, int s)
+static int64_t I64_asr(int64_t x, int s)
 {
-  int64 res;
+  int64_t res;
   s = s & 63;
   if (s == 0) return x;
   if (s < 32) {
     res.l = (x.l >> s) | (x.h << (32 - s));
-    res.h = (int32) x.h >> s;
+    res.h = (int32_t) x.h >> s;
   } else {
-    res.l = (int32) x.h >> (s - 32);
-    res.h = (int32) x.h >> 31;
+    res.l = (int32_t) x.h >> (s - 32);
+    res.h = (int32_t) x.h >> 31;
   }
   return res;
 }
@@ -173,15 +173,15 @@ static int64 I64_asr(int64 x, int s)
 #define I64_SHL1(x) x.h = (x.h << 1) | (x.l >> 31); x.l <<= 1
 #define I64_SHR1(x) x.l = (x.l >> 1) | (x.h << 31); x.h >>= 1
 
-static void I64_udivmod(uint64 modulus, uint64 divisor,
-                        uint64 * quo, uint64 * mod)
+static void I64_udivmod(uint64_t modulus, uint64_t divisor,
+                        uint64_t * quo, uint64_t * mod)
 {
-  int64 quotient, mask;
+  int64_t quotient, mask;
   int cmp;
 
   quotient.h = 0; quotient.l = 0;
   mask.h = 0; mask.l = 1;
-  while ((int32) divisor.h >= 0) {
+  while ((int32_t) divisor.h >= 0) {
     cmp = I64_ucompare(divisor, modulus);
     I64_SHL1(divisor);
     I64_SHL1(mask);
@@ -199,27 +199,27 @@ static void I64_udivmod(uint64 modulus, uint64 divisor,
   *mod = modulus;
 }
 
-static int64 I64_div(int64 x, int64 y)
+static int64_t I64_div(int64_t x, int64_t y)
 {
-  int64 q, r;
-  int32 sign;
+  int64_t q, r;
+  int32_t sign;
 
   sign = x.h ^ y.h;
-  if ((int32) x.h < 0) x = I64_neg(x);
-  if ((int32) y.h < 0) y = I64_neg(y);
+  if ((int32_t) x.h < 0) x = I64_neg(x);
+  if ((int32_t) y.h < 0) y = I64_neg(y);
   I64_udivmod(x, y, &q, &r);
   if (sign < 0) q = I64_neg(q);
   return q;
 }
 
-static int64 I64_mod(int64 x, int64 y)
+static int64_t I64_mod(int64_t x, int64_t y)
 {
-  int64 q, r;
-  int32 sign;
+  int64_t q, r;
+  int32_t sign;
 
   sign = x.h;
-  if ((int32) x.h < 0) x = I64_neg(x);
-  if ((int32) y.h < 0) y = I64_neg(y);
+  if ((int32_t) x.h < 0) x = I64_neg(x);
+  if ((int32_t) y.h < 0) y = I64_neg(y);
   I64_udivmod(x, y, &q, &r);
   if (sign < 0) r = I64_neg(r);
   return r;
@@ -227,42 +227,42 @@ static int64 I64_mod(int64 x, int64 y)
 
 /* Coercions */
 
-static int64 I64_of_int32(int32 x)
+static int64_t I64_of_int32(int32_t x)
 {
-  int64 res;
+  int64_t res;
   res.l = x;
   res.h = x >> 31;
   return res;
 }
 
-#define I64_to_int32(x) ((int32) (x).l)
+#define I64_to_int32(x) ((int32_t) (x).l)
 
 /* Note: we assume sizeof(intnat) = 4 here, which is true otherwise
    autoconfiguration would have selected native 64-bit integers */
 #define I64_of_intnat I64_of_int32
 #define I64_to_intnat I64_to_int32
 
-static double I64_to_double(int64 x)
+static double I64_to_double(int64_t x)
 {
   double res;
-  int32 sign = x.h;
+  int32_t sign = x.h;
   if (sign < 0) x = I64_neg(x);
   res = ldexp((double) x.h, 32) + x.l;
   if (sign < 0) res = -res;
   return res;
 }
 
-static int64 I64_of_double(double f)
+static int64_t I64_of_double(double f)
 {
-  int64 res;
+  int64_t res;
   double frac, integ;
   int neg;
 
   neg = (f < 0);
   f = fabs(f);
   frac = modf(ldexp(f, -32), &integ);
-  res.h = (uint32) integ;
-  res.l = (uint32) ldexp(frac, 32);
+  res.h = (uint32_t) integ;
+  res.l = (uint32_t) ldexp(frac, 32);
   if (neg) res = I64_neg(res);
   return res;
 }

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -242,7 +242,7 @@ let pretype_sort evdref = function
   | GProp c -> judge_of_prop_contents c
   | GType _ -> evd_comb0 judge_of_new_Type evdref
 
-exception Found of fixpoint
+exception FoundFixpoint of fixpoint
 
 let new_type_evar evdref env loc =
   evd_comb0 (fun evd -> Evarutil.new_type_evar evd env ~src:(loc,InternalHole)) evdref

--- a/toplevel/obligations.ml
+++ b/toplevel/obligations.ml
@@ -974,12 +974,12 @@ let admit_obligations n =
       obls;
     ignore(update_obls prg obls 0)
 
-exception Found of int
+exception FoundInt of int
 
 let array_find f arr =
-  try Array.iteri (fun i x -> if f x then raise (Found i)) arr;
+  try Array.iteri (fun i x -> if f x then raise (FoundInt i)) arr;
     raise Not_found
-  with Found i -> i
+  with FoundInt i -> i
 
 let next_obligation n tac =
   let prg = get_prog_err n in


### PR DESCRIPTION
Hi Maxime,

native-coq compiles well, but when trying to compile something depending on it, I get the following error:

parsing/grammar.cma: undefined reference to global Unix

This commit solves the problem, but I do not know if it is the good solution.

Best,
Chantal.
